### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
 #  Tk.jl does not work under Julia 0.5 yet
 #  - nightly
 notifications:


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested